### PR TITLE
deps: use babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,5 @@ including this file, may be copied, modified, propagated, or distributed
 except according to the terms contained in the LICENSE file.
 */
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": ["env", "stage-2"],
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "babel-core": "^6.0.0",
     "babel-plugin-transform-runtime": "^6.0.0",
-    "babel-preset-es2015": "^6.0.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.0.0",
     "babel-runtime": "^6.0.0",
     "babelify": "^7.2.0",


### PR DESCRIPTION
As recommended by babeljs.io/env, the "babel-preset-env" enables easier  forward compatibility with future babel presets as JS features get standardized.  It also removes the warning from npm and yarn installs.

More information on the [babel site](http://babeljs.io/env).

Closes #19.